### PR TITLE
Deprecate wcn-scraper in favour of new repository.

### DIFF
--- a/wcn-scraper/README.md
+++ b/wcn-scraper/README.md
@@ -1,5 +1,7 @@
 # Fetching jobs from WCN
 
+This has been deprecated in favour of [ministryofjustice/hmpps-job-feed-parser](https://github.com/ministryofjustice/hmpps-job-feed-parser).
+
 ## RSS
 
 WCN publish an RSS feed of all jobs, at;


### PR DESCRIPTION
A deprecation notice has been added to the wcn-scraper README pointing to its new location. The scraper has been split out into its own repository, ministryofjustice/hmpps-job-feed-parser, where it can be further developed and hardened.

@digitalronin There's not much in the new repository yet, but I'm working with @tatyree to build upon & harden your prototype.